### PR TITLE
fix order of replaceInFile arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ $skeletor->pause(5);
 #### Replace In File
 
 ```php
-$skeletor->replaceInFile('path/to/file.txt', 'search string', 'replace string');
+$skeletor->replaceInFile( 'search string', 'replace string', 'path/to/file.txt')
 ```
 
 #### Preg Replace In File


### PR DESCRIPTION
The order of methods was incorrect; it should be: search, replace, then file.