### PR TITLE
fix order of params in pregReplaceInFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,5 +194,5 @@ $skeletor->replaceInFile('path/to/file.txt', 'search string', 'replace string');
 #### Preg Replace In File
 
 ```php
-$skeletor->pregReplaceInFile('path/to/file.txt', '/pattern/', 'replace string');
+$skeletor->pregReplaceInFile('/pattern/', 'replace string', 'path/to/file.txt');
 ```


### PR DESCRIPTION
The order of methods was incorrect; it should be: pattern, replace, then file.